### PR TITLE
Update to handle duplicate region names

### DIFF
--- a/src/poly_writer.rs
+++ b/src/poly_writer.rs
@@ -6,9 +6,26 @@ use std::io::prelude::*;
 pub fn write(folder: &str, polygons: &[Polygon]) -> std::io::Result<usize> {
     let _create_result = create_dir_all(folder);
 
-    for polygon in polygons {
+    // Array of length counting how many times this region name is duplicated (see: https://github.com/AndGem/osm_extract_polygon/issues/10)
+    let dupnamecount = polygons.map(|v|  0 ); // Initialize as all-zeros with same length as polygons.len()
+
+    // For each region name, count how many times we find it in the list of all regions
+    for i in 1..dupnamecount.len() {
+      dupnamecount[i] = polygons.iter().filter(|&p| *p == polygons[i]).count(); // Does "==" do string comparison in Rust?
+    }
+
+    for pi = 0..polygons.len() { // Changed, since we need to be certain that the iteration proceeds in sync over polygons[] and dupnamecount[]
+        let polygon = polygons[pi];
         let name: String = make_safe(&polygon.name);
-        let filename = format!("{}/{}.poly", folder, name);
+
+        // Handle potential duplicated region names
+        // The bug is described here: https://github.com/AndGem/osm_extract_polygon/issues/10
+        // In the normal case of a unique region name this will be decremented from 1 to 0 here
+        // In the case of, say, 3 regions with the same name, this will be decremented from 3 to 2 here, 
+        // and the filename will be suffixed in descending order with "_2", "_1","_0" suffixes to ensure unique filenames.
+        dupnamecount[pi]--;
+        let filename = (dupnamecount[0]>0) ? format!("{}/{}_{}.poly", folder, name, dupnamecount[pi]) : format!("{}/{}.poly", folder, name)
+
         println!("{}", filename);
         let mut file = File::create(filename)?;
         file.write_all(&polygon.name.as_bytes())?;


### PR DESCRIPTION
Added suffix like "_0", "_1", etc to output filenames for nonunique region names. See Issue: https://github.com/AndGem/osm_extract_polygon/issues/10

This is not compiled or tested at all! I am hoping AndGem can do this and create a new release. I just tried to sketch out a solution. I've never coded in Rust nor have a dev environment set up.

