### PR TITLE
performance improvement for writing poly files

### DIFF
--- a/src/output/file_writer_poly.rs
+++ b/src/output/file_writer_poly.rs
@@ -1,6 +1,7 @@
 use crate::converter::Polygon;
 use crate::output::output_handler::FileWriter;
 
+use std::fmt;
 use std::fs::File;
 use std::io::prelude::*;
 
@@ -8,20 +9,25 @@ pub struct PolyWriter {}
 
 impl FileWriter for PolyWriter {
     fn write_to_file(&self, file: &mut File, polygon: &Polygon) -> std::io::Result<()> {
-        file.write_all(&polygon.name.as_bytes())?;
-        file.write_all(b"\n")?;
+        let mut output: String = String::new();
+        output.push_str(&polygon.name);
+        output.push('\n');
+
         let mut index: i32 = 1;
 
-        //TODO: improve performance by preparing output
         for points in &polygon.points {
-            file.write_fmt(format_args!("area_{}\n", index))?;
+            let area_id_str = fmt::format(format_args!("area_{}\n", index));
+            output.push_str(&area_id_str);
             for point in points {
-                file.write_fmt(format_args!("\t{} \t{}\n", point.lon, point.lat))?;
+                let point_str = fmt::format(format_args!("\t{} \t{}\n", point.lon, point.lat));
+                output.push_str(&point_str);
             }
-            file.write_all(b"END\n")?;
+            output.push_str("END\n");
             index += 1;
         }
-        file.write_all(b"END\n")?;
+        output.push_str("END\n");
+        file.write_all(output.as_bytes())?;
+
         Ok(())
     }
 }

--- a/src/output/output_handler.rs
+++ b/src/output/output_handler.rs
@@ -5,6 +5,7 @@ use crate::output::file_writer_poly::PolyWriter;
 use crate::output::OverwriteConfiguration;
 
 use std::fs::File;
+use std::time::Instant;
 
 use std::collections::HashMap;
 use std::fs::create_dir_all;
@@ -51,6 +52,9 @@ impl OutputHandler {
         let poly_writer = PolyWriter {};
         let geojson_writer = GeoJsonWriter {};
 
+        let now = Instant::now();
+        println!("writing output files...");
+
         for (name, polygon) in filename_polys {
             let filename_wo_ext = format!("{}/{}", base_folder, name);
             if self.write_poly {
@@ -66,6 +70,8 @@ impl OutputHandler {
                 }
             }
         }
+
+        println!("finished writing! {}s", now.elapsed().as_secs());
 
         Ok(file_count)
     }


### PR DESCRIPTION
This PR improves the performance of writing poly files substantially, by constructing the whole content of each file first in memory before writing it all out at once, instead of writing every tiny bit of data separately.